### PR TITLE
Enable native devcontainer updates via renovate

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,7 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
 	"name": "Python",
 	"image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2.10.2": {},
 		"ghcr.io/devcontainers/features/github-cli:1.0.11": {},

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,48 +12,18 @@
     ":pinDevDependencies"             // Pin dev dependencies also
   ],
   // Files to ignore
-  // "ignorePaths": [
-  //   "docs/requirements.txt"
-  // ],
+  "ignorePaths": [
+    ".venv"
+  ],
   "labels": [
     "dependencies"
   ],
   "lockFileMaintenance": {"enabled": true},
   "packageRules": [
     {
-      "description": "Update devcontainer images in a single PR",
-      "groupName": "devcontainer",
-      "matchFileNames": [".devcontainer/devcontainer.json"]
-    },
-    {
       "description": "Update renovatebot/pre-commit-hooks weekly to decrease noise",
       "matchPackageNames": ["renovatebot/pre-commit-hooks"],
       "schedule": ["before 9am on monday"]
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "devcontainer base image",
-      "fileMatch": [
-        "^.devcontainer/devcontainer.json$"
-      ],
-      "matchStrings": [
-        "\"image\"\\s*:\\s*\"(?<depName>.*?):(?<currentValue>.*?)(@(?<currentDigest>sha256:[a-f0-9]+))?\""
-      ],
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "description": "devcontainer feature images",
-      "fileMatch": [
-        "^.devcontainer/devcontainer.json$"
-      ],
-      "matchStrings": [
-        // devcontainer features don't support sha256 digests
-        "\"(?<depName>.*?):(?<currentValue>.*?)\"\\s*:\\s*"
-      ],
-      "datasourceTemplate": "docker"
     }
   ],
   // "schedule": [


### PR DESCRIPTION
- Renovate can't parse the devcontainer.json file
  if it has comments :(
- Removes the regex matcher from when I was doing devcontainer
  updates manually in renovate

Signed-off-by: John Strunk <jstrunk@redhat.com>
