### PR TITLE
Re-enable digest pinning for devcontainer

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,8 +26,9 @@
       "schedule": ["before 9am on monday"]
     },
     {
-      "description": "Don't pin digests in devcontainer.json because it's not supported in features",
+      "description": "Devcontainer 'features' don't support digest pinning",
       "matchManagers": ["devcontainer"],
+      "matchDepTypes": ["feature"],
       "pinDigests": false
     }
   ],


### PR DESCRIPTION
renovate has been updated to distinguish between the base image and the
"feature" images, so we can now enable pinning for the base image, but
keep it disabled for the features since they don't support it.

Signed-off-by: John Strunk <jstrunk@redhat.com>
