### PR TITLE
Enable Renovate to update the jira-summarizer.yaml file

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,11 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "kubernetes": {
+    "fileMatch": [
+      "^jira-summarizer\\.yaml$"
+    ]
+  },
   "packageRules": [
     {
       "description": "Update renovatebot/pre-commit-hooks weekly to decrease noise",

--- a/jira-summarizer.yaml
+++ b/jira-summarizer.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: summarizer
-          image: ghcr.io/johnstrunk/jira-summarizer:latest
+          image: ghcr.io/johnstrunk/jira-summarizer:1.1.0
           args:
             - "--log-level"
             - "INFO"


### PR DESCRIPTION
- Specify the container image tag
- Add a fileMatch rule to the Kubernetes preset to match the
  jira-summarizer.yaml file

Signed-off-by: John Strunk <jstrunk@redhat.com>
