### PR TITLE
Hardcode my username as an allowed author for summary updates

### DIFF
--- a/jira_howto.ipynb
+++ b/jira_howto.ipynb
@@ -146,7 +146,8 @@
    "outputs": [],
    "source": [
     "# Get a list of the custom fields in this issue by finding all fields that start with \"customfield_\"\n",
-    "custom_fields = [k for k in issue[\"fields\"].keys() if k.startswith(\"customfield_\")]\n",
+    "custom_fields = [k for k in issue[\"fields\"].keys()\n",
+    "                 if k.startswith(\"customfield_\")]\n",
     "for field in custom_fields:\n",
     "    if issue[\"fields\"].get(field, None) is None:\n",
     "        continue\n",
@@ -287,7 +288,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jira.user(username=\"assisted-installer-bot\")"
+    "jira.user(username=\"jstrunk@redhat.com\")"
    ]
   },
   {

--- a/summarizer.py
+++ b/summarizer.py
@@ -219,9 +219,12 @@ def summary_last_updated(issue: Issue) -> datetime:
         return last_update
 
     for change in issue.changelog:
-        if change.author == get_self(
-            issue.client
-        ).display_name and "Status Summary" in [chg.field for chg in change.changes]:
+        # This is to prevent regenerating summaries due to the summary bot
+        # being moved to its own account instead of using mine
+        if change.author in [
+            get_self(issue.client).display_name,
+            "John Strunk",
+        ] and "Status Summary" in [chg.field for chg in change.changes]:
             last_update = max(last_update, change.created)
 
     return last_update


### PR DESCRIPTION
This is a temporary fix to prevent the summary bot from regenerating
summaries due to the bot being moved to its own account instead of using
mine.

Signed-off-by: John Strunk <jstrunk@redhat.com>
