### PR TITLE
Disable recursion by default in summarize_api.py

### DIFF
--- a/summarize_api.py
+++ b/summarize_api.py
@@ -22,6 +22,8 @@ import summarizer
 from jiraissues import issue_cache
 from simplestats import Timer
 
+_DEFAULT_RECURSION_DEPTH = 0
+
 
 def create_app():
     """Create the Flask app"""
@@ -51,7 +53,7 @@ def create_app():
         issue_cache.remove(key)
 
         issue = issue_cache.get_issue(client, key)
-        summary = summarizer.summarize_issue(issue, max_depth=1)
+        summary = summarizer.summarize_issue(issue, max_depth=_DEFAULT_RECURSION_DEPTH)
         req.stop()
         getissue_stats = Timer.stats("IssueCache.get_issue")
         fetchrelated_stats = Timer.stats("Issue._fetch_related")

--- a/summarize_issue.py
+++ b/summarize_issue.py
@@ -9,6 +9,7 @@ import os
 from atlassian import Jira  # type: ignore
 
 from jiraissues import Issue
+from simplestats import Timer
 from summarizer import summarize_issue
 
 
@@ -73,4 +74,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    with Timer(__name__):
+        main()


### PR DESCRIPTION
Some of the Jira issues have a large number of
subtasks, which can cause the API requests to take
too long and time out.

Signed-off-by: John Strunk <jstrunk@redhat.com>
